### PR TITLE
Improve report messages.

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -111,7 +111,7 @@ func reportAboutErrorType(pass *analysis.Pass, typePos token.Pos, typeName strin
 	} else {
 		form = "XxxError"
 	}
-	pass.Reportf(typePos, "the error type `%s` should be of the form %s", typeName, form)
+	pass.Reportf(typePos, "the type name `%s` should conform to the `%s` format", typeName, form)
 }
 
 func reportAboutErrorVar(pass *analysis.Pass, pos token.Pos, varName string) {
@@ -121,7 +121,7 @@ func reportAboutErrorVar(pass *analysis.Pass, pos token.Pos, varName string) {
 	} else {
 		form = "ErrXxx"
 	}
-	pass.Reportf(pos, "the sentinel error `%s` should be of the form %s", varName, form)
+	pass.Reportf(pos, "the variable name `%s` should conform to the `%s` format", varName, form)
 }
 
 func getPkgFromPath(p string) string {

--- a/pkg/analyzer/testdata/src/regular/error_types.go
+++ b/pkg/analyzer/testdata/src/regular/error_types.go
@@ -9,14 +9,14 @@ type DNSConfigError struct{}
 
 func (D DNSConfigError) Error() string { return "DNS config error" }
 
-type someTypeWithoutPtr struct{}           // want "the error type `someTypeWithoutPtr` should be of the form xxxError"
+type someTypeWithoutPtr struct{}           // want "the type name `someTypeWithoutPtr` should conform to the `xxxError` format"
 func (s someTypeWithoutPtr) Error() string { return "someTypeWithoutPtr" }
 
-type SomeTypeWithoutPtr struct{}           // want "the error type `SomeTypeWithoutPtr` should be of the form XxxError"
+type SomeTypeWithoutPtr struct{}           // want "the type name `SomeTypeWithoutPtr` should conform to the `XxxError` format"
 func (s SomeTypeWithoutPtr) Error() string { return "SomeTypeWithoutPtr" }
 
-type someTypeWithPtr struct{}            // want "the error type `someTypeWithPtr` should be of the form xxxError"
+type someTypeWithPtr struct{}            // want "the type name `someTypeWithPtr` should conform to the `xxxError` format"
 func (s *someTypeWithPtr) Error() string { return "someTypeWithPtr" }
 
-type SomeTypeWithPtr struct{}            // want "the error type `SomeTypeWithPtr` should be of the form XxxError"
+type SomeTypeWithPtr struct{}            // want "the type name `SomeTypeWithPtr` should conform to the `XxxError` format"
 func (s *SomeTypeWithPtr) Error() string { return "SomeTypeWithPtr" }

--- a/pkg/analyzer/testdata/src/regular/sentinel.go
+++ b/pkg/analyzer/testdata/src/regular/sentinel.go
@@ -10,11 +10,11 @@ var (
 	ErrEndOfFile = errors.New("end of file")
 	errEndOfFile = errors.New("end of file")
 
-	EndOfFileError = errors.New("end of file") // want "the sentinel error `EndOfFileError` should be of the form ErrXxx"
-	ErrorEndOfFile = errors.New("end of file") // want "the sentinel error `ErrorEndOfFile` should be of the form ErrXxx"
-	EndOfFileErr   = errors.New("end of file") // want "the sentinel error `EndOfFileErr` should be of the form ErrXxx"
-	endOfFileError = errors.New("end of file") // want "the sentinel error `endOfFileError` should be of the form errXxx"
-	errorEndOfFile = errors.New("end of file") // want "the sentinel error `errorEndOfFile` should be of the form errXxx"
+	EndOfFileError = errors.New("end of file") // want "the variable name `EndOfFileError` should conform to the `ErrXxx` format"
+	ErrorEndOfFile = errors.New("end of file") // want "the variable name `ErrorEndOfFile` should conform to the `ErrXxx` format"
+	EndOfFileErr   = errors.New("end of file") // want "the variable name `EndOfFileErr` should conform to the `ErrXxx` format"
+	endOfFileError = errors.New("end of file") // want "the variable name `endOfFileError` should conform to the `errXxx` format"
+	errorEndOfFile = errors.New("end of file") // want "the variable name `errorEndOfFile` should conform to the `errXxx` format"
 )
 
 const maxSize = 256
@@ -23,8 +23,8 @@ var (
 	ErrOutOfSize = fmt.Errorf("out of size (max %d)", maxSize)
 	errOutOfSize = fmt.Errorf("out of size (max %d)", maxSize)
 
-	OutOfSizeError = fmt.Errorf("out of size (max %d)", maxSize) // want "the sentinel error `OutOfSizeError` should be of the form ErrXxx"
-	outOfSizeError = fmt.Errorf("out of size (max %d)", maxSize) // want "the sentinel error `outOfSizeError` should be of the form errXxx"
+	OutOfSizeError = fmt.Errorf("out of size (max %d)", maxSize) // want "the variable name `OutOfSizeError` should conform to the `ErrXxx` format"
+	outOfSizeError = fmt.Errorf("out of size (max %d)", maxSize) // want "the variable name `outOfSizeError` should conform to the `errXxx` format"
 )
 
 func errInsideFuncIsNotSentinel() error {

--- a/pkg/analyzer/testdata/src/regular/sentinel_from_alias.go
+++ b/pkg/analyzer/testdata/src/regular/sentinel_from_alias.go
@@ -7,10 +7,10 @@ import (
 
 var (
 	ErrAlias = stderrors.New("err from alias")
-	AliasErr = stderrors.New("err from alias") // want "the sentinel error `AliasErr` should be of the form ErrXxx"
+	AliasErr = stderrors.New("err from alias") // want "the variable name `AliasErr` should conform to the `ErrXxx` format"
 )
 
 var (
 	ErrOutOfSize2   = stdfmt.Errorf("out of size (max %d)", maxSize)
-	OutOfSizeError2 = stdfmt.Errorf("out of size (max %d)", maxSize) // want "the sentinel error `OutOfSizeError2` should be of the form ErrXxx"
+	OutOfSizeError2 = stdfmt.Errorf("out of size (max %d)", maxSize) // want "the variable name `OutOfSizeError2` should conform to the `ErrXxx` format"
 )

--- a/pkg/analyzer/testdata/src/regular/sentinel_from_constants.go
+++ b/pkg/analyzer/testdata/src/regular/sentinel_from_constants.go
@@ -9,6 +9,6 @@ func (e constError) Error() string {
 const (
 	ErrTooManyErrors constError = "too many errors found"
 
-	ErrorTooMany1 constError = "too many errors found"             // want "the sentinel error `ErrorTooMany1` should be of the form ErrXxx"
-	ErrorTooMany2            = constError("too many errors found") // want "the sentinel error `ErrorTooMany2` should be of the form ErrXxx"
+	ErrorTooMany1 constError = "too many errors found"             // want "the variable name `ErrorTooMany1` should conform to the `ErrXxx` format"
+	ErrorTooMany2            = constError("too many errors found") // want "the variable name `ErrorTooMany2` should conform to the `ErrXxx` format"
 )

--- a/pkg/analyzer/testdata/src/regular/sentinel_from_funcs.go
+++ b/pkg/analyzer/testdata/src/regular/sentinel_from_funcs.go
@@ -11,28 +11,28 @@ var (
 	ErrF = &SomeTypeWithPtr{}
 	ErrG = SomeTypeWithoutPtr{}
 
-	AErr = newSomeTypeWithPtr()     // want "the sentinel error `AErr` should be of the form ErrXxx"
-	BErr = newSomeTypeWithPtr2()    // want "the sentinel error `BErr` should be of the form ErrXxx"
-	CErr = newSomeTypeWithoutPtr()  // want "the sentinel error `CErr` should be of the form ErrXxx"
-	DErr = newSomeTypeWithoutPtr2() // want "the sentinel error `DErr` should be of the form ErrXxx"
-	EErr = new(SomeTypeWithPtr)     // want "the sentinel error `EErr` should be of the form ErrXxx"
-	FErr = &SomeTypeWithPtr{}       // want "the sentinel error `FErr` should be of the form ErrXxx"
-	GErr = SomeTypeWithoutPtr{}     // want "the sentinel error `GErr` should be of the form ErrXxx"
+	AErr = newSomeTypeWithPtr()     // want "the variable name `AErr` should conform to the `ErrXxx` format"
+	BErr = newSomeTypeWithPtr2()    // want "the variable name `BErr` should conform to the `ErrXxx` format"
+	CErr = newSomeTypeWithoutPtr()  // want "the variable name `CErr` should conform to the `ErrXxx` format"
+	DErr = newSomeTypeWithoutPtr2() // want "the variable name `DErr` should conform to the `ErrXxx` format"
+	EErr = new(SomeTypeWithPtr)     // want "the variable name `EErr` should conform to the `ErrXxx` format"
+	FErr = &SomeTypeWithPtr{}       // want "the variable name `FErr` should conform to the `ErrXxx` format"
+	GErr = SomeTypeWithoutPtr{}     // want "the variable name `GErr` should conform to the `ErrXxx` format"
 
-	AErrr error = newSomeTypeWithPtr2()   // want "the sentinel error `AErrr` should be of the form ErrXxx"
-	BErrr error = newSomeTypeWithoutPtr() // want "the sentinel error `BErrr` should be of the form ErrXxx"
-	CErrr error = new(SomeTypeWithPtr)    // want "the sentinel error `CErrr` should be of the form ErrXxx"
-	DErrr error = &SomeTypeWithPtr{}      // want "the sentinel error `DErrr` should be of the form ErrXxx"
-	EErrr error = SomeTypeWithoutPtr{}    // want "the sentinel error `EErrr` should be of the form ErrXxx"
+	AErrr error = newSomeTypeWithPtr2()   // want "the variable name `AErrr` should conform to the `ErrXxx` format"
+	BErrr error = newSomeTypeWithoutPtr() // want "the variable name `BErrr` should conform to the `ErrXxx` format"
+	CErrr error = new(SomeTypeWithPtr)    // want "the variable name `CErrr` should conform to the `ErrXxx` format"
+	DErrr error = &SomeTypeWithPtr{}      // want "the variable name `DErrr` should conform to the `ErrXxx` format"
+	EErrr error = SomeTypeWithoutPtr{}    // want "the variable name `EErrr` should conform to the `ErrXxx` format"
 
 	ErrByAnonymousFunc = func() error { return nil }
-	ByAnonymousFuncErr = func() error { return io.EOF }() // want "the sentinel error `ByAnonymousFuncErr` should be of the form ErrXxx"
+	ByAnonymousFuncErr = func() error { return io.EOF }() // want "the variable name `ByAnonymousFuncErr` should conform to the `ErrXxx` format"
 )
 
 var (
-	InitializedLaterError            error              // want "the sentinel error `InitializedLaterError` should be of the form ErrXxx"
-	InitializedLaterImplicitError    SomeTypeWithoutPtr // want "the sentinel error `InitializedLaterImplicitError` should be of the form ErrXxx"
-	InitializedLaterImplicitPtrError *SomeTypeWithPtr   // want "the sentinel error `InitializedLaterImplicitPtrError` should be of the form ErrXxx"
+	InitializedLaterError            error              // want "the variable name `InitializedLaterError` should conform to the `ErrXxx` format"
+	InitializedLaterImplicitError    SomeTypeWithoutPtr // want "the variable name `InitializedLaterImplicitError` should conform to the `ErrXxx` format"
+	InitializedLaterImplicitPtrError *SomeTypeWithPtr   // want "the variable name `InitializedLaterImplicitPtrError` should conform to the `ErrXxx` format"
 )
 
 func init() {

--- a/pkg/analyzer/testdata/src/regular/sentinel_from_types.go
+++ b/pkg/analyzer/testdata/src/regular/sentinel_from_types.go
@@ -4,12 +4,12 @@ import "net"
 
 var (
 	InvalidAddrError       = new(net.AddrError) // unsupported
-	InvalidAddrErr   error = new(net.AddrError) // want "the sentinel error `InvalidAddrErr` should be of the form ErrXxx"
+	InvalidAddrErr   error = new(net.AddrError) // want "the variable name `InvalidAddrErr` should conform to the `ErrXxx` format"
 	NotErr                 = new(NotErrorType)
 
-	Aa = new(someTypeWithPtr) // want "the sentinel error `Aa` should be of the form ErrXxx"
-	Bb = someTypeWithoutPtr{} // want "the sentinel error `Bb` should be of the form ErrXxx"
+	Aa = new(someTypeWithPtr) // want "the variable name `Aa` should conform to the `ErrXxx` format"
+	Bb = someTypeWithoutPtr{} // want "the variable name `Bb` should conform to the `ErrXxx` format"
 
-	cC error = new(someTypeWithPtr) // want "the sentinel error `cC` should be of the form errXxx"
-	dD error = someTypeWithoutPtr{} // want "the sentinel error `dD` should be of the form errXxx"
+	cC error = new(someTypeWithPtr) // want "the variable name `cC` should conform to the `errXxx` format"
+	dD error = someTypeWithoutPtr{} // want "the variable name `dD` should conform to the `errXxx` format"
 )

--- a/pkg/analyzer/testdata/src/unusual/newfunc/user_new_func.go
+++ b/pkg/analyzer/testdata/src/unusual/newfunc/user_new_func.go
@@ -1,6 +1,6 @@
 package newfunc
 
-var FromUserNewError = new() // want "the sentinel error `FromUserNewError` should be of the form ErrXxx"
+var FromUserNewError = new() // want "the variable name `FromUserNewError` should conform to the `ErrXxx` format"
 
 func new() error {
 	return nil


### PR DESCRIPTION
the sentinel error `EndOfFileError` should be of the form ErrXxx -> The variable name `EndOfFileError` should conform to the `ErrXxx` format
the error type `someTypeWithoutPtr` should be of the form xxxError -> The type name `someTypeWithoutPtr` should conform to the `xxxError` format
