### PR TITLE
Update link to naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ errname ./...
 
 ## Motivation
 
-[The convention](https://github.com/golang/go/wiki/Errors#naming) states that
+[The convention](https://go.dev/wiki/Errors#naming) states that
 > Error types end in "Error" and error variables start with "Err" or "err".
 
 This can be found in the standard Go library:


### PR DESCRIPTION
The wiki page on errors in go has moved to go.dev, so repoint the link there instead.